### PR TITLE
Fix missing index for intro-to-github

### DIFF
--- a/content/education-academic/intro-to-github/_index.md
+++ b/content/education-academic/intro-to-github/_index.md
@@ -12,6 +12,7 @@ aliases:
     - /devel/intro-to-github/
     - /develop-design/29/introduction-to-git-and-github/
     - /docs/education-academic/intro-to-github/
+    - /education-academic/intro-to-github/introduction-to-git-and-github/
 author: Daniel F. Dickinson
 date: 2021-03-08T09:46:40+00:00
 publishDate: 2020-08-29T17:32:00+00:00

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wildtechgarden",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wildtechgarden",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "CC-BY-SA-4.0",
       "devDependencies": {
         "html-validate": "^7.18.1",


### PR DESCRIPTION
This resulted in the Apache file list being used.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>